### PR TITLE
fix(#9): removing main.go is useless

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,7 +1,0 @@
-package main
-
-import "fmt"
-
-func main() {
-	fmt.Println("Hello World!")
-}


### PR DESCRIPTION
Since the **main.go** file was only used during the project initialization phase and will no longer be needed, it should be removed.